### PR TITLE
Conflicting with paypal setting issue fixed

### DIFF
--- a/inc/checkout-hide-optional-fields.php
+++ b/inc/checkout-hide-optional-fields.php
@@ -20,7 +20,10 @@ class FluidCheckout_CheckoutHideOptionalFields extends FluidCheckout {
 	 */
 	public function hooks() {
 		// WooCommerce fields output
-		add_filter( 'woocommerce_form_field', array( $this, 'add_optional_form_field_link_button' ), 100, 4 );
+
+		if ( ! is_admin() ) {
+			add_filter( 'woocommerce_form_field', array( $this, 'add_optional_form_field_link_button' ), 100, 4 );
+		}
 	}
 
 

--- a/inc/checkout-hide-optional-fields.php
+++ b/inc/checkout-hide-optional-fields.php
@@ -19,11 +19,11 @@ class FluidCheckout_CheckoutHideOptionalFields extends FluidCheckout {
 	 * Initialize hooks.
 	 */
 	public function hooks() {
-		// WooCommerce fields output
+		// Bail if not on front end
+		if ( is_admin() ) { return; }
 
-		if ( ! is_admin() ) {
-			add_filter( 'woocommerce_form_field', array( $this, 'add_optional_form_field_link_button' ), 100, 4 );
-		}
+		// WooCommerce fields output
+		add_filter( 'woocommerce_form_field', array( $this, 'add_optional_form_field_link_button' ), 100, 4 );
 	}
 
 

--- a/inc/checkout-validation.php
+++ b/inc/checkout-validation.php
@@ -19,6 +19,10 @@ class FluidCheckout_Validation extends FluidCheckout {
 	 * Initialize hooks.
 	 */
 	public function hooks() {
+		if ( is_admin() ) {
+			return;
+		}
+
 		// Body class
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );
 

--- a/inc/checkout-validation.php
+++ b/inc/checkout-validation.php
@@ -19,9 +19,8 @@ class FluidCheckout_Validation extends FluidCheckout {
 	 * Initialize hooks.
 	 */
 	public function hooks() {
-		if ( is_admin() ) {
-			return;
-		}
+		// Bail if not on front end
+		if ( is_admin() ) { return; }
 
 		// Body class
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );


### PR DESCRIPTION
Fix PayPal Gateway settings page errors out when Fluid Checkout is activated

Plugin link:
https://wordpress.org/plugins/woocommerce-paypal-payments/

Topic link:
https://wordpress.org/support/topic/plugin-causes-error-when-saving-paypal-gateway-settings/